### PR TITLE
Add alternative URL broker scheme

### DIFF
--- a/src/ibmiotf/__init__.py
+++ b/src/ibmiotf/__init__.py
@@ -31,6 +31,18 @@ from encodings.base64_codec import base64_encode
 
 __version__ = "0.2.8"
 
+def _getBrokerAddress(domain = None, orgId = None, completeBrokerUrl = None):
+	# Compute broker adress
+	if not completeBrokerUrl and (not domain or not orgId):
+		raise ConfigurationException(
+			"No full broker URL given, so both domain and organisation "
+			"must be specified"
+		)
+	return (
+		completeBrokerUrl if completeBrokerUrl
+		else orgId + '.messaging.' + domain
+	)
+
 class Message:
 	def __init__(self, data, timestamp=None):
 		self.data = data
@@ -38,11 +50,12 @@ class Message:
 
 class AbstractClient:
 	def __init__(self, domain, organization, clientId, username, password, port=8883,
-										logHandlers=None, cleanSession="true"):
+										logHandlers=None, cleanSession="true",
+										completeBrokerUrl=None):
 		self.organization = organization
 		self.username = username
 		self.password = password
-		self.address = organization + ".messaging." + domain
+		self.address = _getBrokerAddress(domain, organization, completeBrokerUrl)
 		self.port = port
 		self.keepAlive = 60
 

--- a/src/ibmiotf/application.py
+++ b/src/ibmiotf/application.py
@@ -188,6 +188,7 @@ class Client(ibmiotf.AbstractClient):
 			self,
 			domain = self._options['domain'],
 			organization = self._options['org'],
+			completeBrokerUrl = self._options.get('broker-url', None),
 			clientId = clientIdPrefix + ":" + self._options['org'] + ":" + self._options['id'],
 			username = username,
 			password = password,

--- a/src/ibmiotf/device.py
+++ b/src/ibmiotf/device.py
@@ -97,6 +97,7 @@ class Client(AbstractClient):
 			self,
 			domain = self._options['domain'],
 			organization = self._options['org'],
+			completeBrokerUrl = self._options.get('broker-url', None),
 			clientId = "d:" + self._options['org'] + ":" + self._options['type'] + ":" + self._options['id'],
 			username = "use-token-auth" if (self._options['auth-method'] == "token") else None,
 			password = self._options['auth-token'],

--- a/src/ibmiotf/gateway.py
+++ b/src/ibmiotf/gateway.py
@@ -103,6 +103,7 @@ class Client(AbstractClient):
 			self,
 			domain = self._options['domain'],
 			organization = self._options['org'],
+			completeBrokerUrl = self._options.get('broker-url', None),
 			clientId = "g:" + self._options['org'] + ":" + self._options['type'] + ":" + self._options['id'],
 			username = "use-token-auth" if (self._options['auth-method'] == "token") else None,
 			password = self._options['auth-token'],


### PR DESCRIPTION
Now the user can connect to any MQTT broker, not just ones available
under domains matching <orgId>.messaging.<domain>.

When "broker-url" key is included in the Client configuration, both
"org" and "domain" keys are ignored.